### PR TITLE
Reimplement grid editor with PyQt6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Grid Editor
 
-A simple cross-platform Python application using Tkinter that lets you place squares and triangles on a grid using the keyboard.
+A simple cross-platform Python application using PyQt6 that lets you place squares and triangles on a grid using the keyboard.
 
 - **Arrow keys** move the cursor on the grid.
 - Press **S** to place a square.
@@ -12,3 +12,5 @@ Run the application:
 ```bash
 python app.py
 ```
+
+PyQt6 is required to run the application. ReportLab is needed for PDF export.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,13 @@
-import tkinter as tk
-from tkinter import filedialog
+import sys
+from PyQt6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QFileDialog,
+    QAction,
+)
+from PyQt6.QtGui import QPainter, QColor, QPen, QPolygonF
+from PyQt6.QtCore import Qt, QPointF
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 
@@ -9,134 +17,152 @@ except ImportError:  # reportlab might not be installed until runtime
     pdfcanvas = None
 
 
-class GridEditor:
-    def __init__(self, root):
-        self.root = root
+class GridWidget(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
         self.cell_size = 40
         self.cols = 20
         self.rows = 15
         self.width = self.cell_size * self.cols
         self.height = self.cell_size * self.rows
-        self.canvas = tk.Canvas(root, width=self.width, height=self.height, bg="white")
-        self.canvas.pack()
+        self.setFixedSize(self.width, self.height)
         self.shapes = []  # list of dicts with keys: type, x, y
-
-        self._draw_grid()
         self.cursor_x = 0
         self.cursor_y = 0
-        self.cursor = self.canvas.create_rectangle(0, 0, self.cell_size, self.cell_size,
-                                                   outline="red", width=2)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
-        root.bind('<Left>', self._move_left)
-        root.bind('<Right>', self._move_right)
-        root.bind('<Up>', self._move_up)
-        root.bind('<Down>', self._move_down)
-        root.bind('s', self._place_square)
-        root.bind('S', self._place_square)
-        root.bind('t', self._place_triangle)
-        root.bind('T', self._place_triangle)
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.fillRect(self.rect(), Qt.GlobalColor.white)
 
-        menubar = tk.Menu(root)
-        filemenu = tk.Menu(menubar, tearoff=0)
-        filemenu.add_command(label="Save as SVG", command=self.save_svg)
-        filemenu.add_command(label="Save as PDF", command=self.save_pdf)
-        menubar.add_cascade(label="File", menu=filemenu)
-        root.config(menu=menubar)
-
-    def _draw_grid(self):
+        pen = QPen(QColor("lightgray"))
+        painter.setPen(pen)
         for i in range(self.cols + 1):
             x = i * self.cell_size
-            self.canvas.create_line(x, 0, x, self.height, fill="lightgray")
+            painter.drawLine(x, 0, x, self.height)
         for j in range(self.rows + 1):
             y = j * self.cell_size
-            self.canvas.create_line(0, y, self.width, y, fill="lightgray")
+            painter.drawLine(0, y, self.width, y)
 
-    def _update_cursor(self):
-        x1 = self.cursor_x * self.cell_size
-        y1 = self.cursor_y * self.cell_size
-        x2 = x1 + self.cell_size
-        y2 = y1 + self.cell_size
-        self.canvas.coords(self.cursor, x1, y1, x2, y2)
-
-    def _move_left(self, event):
-        if self.cursor_x > 0:
-            self.cursor_x -= 1
-            self._update_cursor()
-
-    def _move_right(self, event):
-        if self.cursor_x < self.cols - 1:
-            self.cursor_x += 1
-            self._update_cursor()
-
-    def _move_up(self, event):
-        if self.cursor_y > 0:
-            self.cursor_y -= 1
-            self._update_cursor()
-
-    def _move_down(self, event):
-        if self.cursor_y < self.rows - 1:
-            self.cursor_y += 1
-            self._update_cursor()
-
-    def _place_square(self, event=None):
-        x = self.cursor_x * self.cell_size
-        y = self.cursor_y * self.cell_size
-        self.canvas.create_rectangle(x, y, x + self.cell_size, y + self.cell_size, fill="black")
-        self.shapes.append({"type": "square", "x": self.cursor_x, "y": self.cursor_y})
-
-    def _place_triangle(self, event=None):
-        x = self.cursor_x * self.cell_size
-        y = self.cursor_y * self.cell_size
-        points = [
-            x + self.cell_size / 2, y,
-            x + self.cell_size, y + self.cell_size,
-            x, y + self.cell_size,
-        ]
-        self.canvas.create_polygon(points, fill="black")
-        self.shapes.append({"type": "triangle", "x": self.cursor_x, "y": self.cursor_y})
-
-    def save_svg(self):
-        filename = filedialog.asksaveasfilename(defaultextension=".svg",
-                                                filetypes=[("SVG files", "*.svg")])
-        if not filename:
-            return
-        svg = ET.Element('svg', width=str(self.width), height=str(self.height),
-                         xmlns="http://www.w3.org/2000/svg", version="1.1")
-        for i in range(self.cols + 1):
-            x = i * self.cell_size
-            ET.SubElement(svg, 'line', x1=str(x), y1="0", x2=str(x), y2=str(self.height),
-                          stroke="lightgray", **{'stroke-width': "1"})
-        for j in range(self.rows + 1):
-            y = j * self.cell_size
-            ET.SubElement(svg, 'line', x1="0", y1=str(y), x2=str(self.width), y2=str(y),
-                          stroke="lightgray", **{'stroke-width': "1"})
+        painter.setBrush(QColor("black"))
         for shape in self.shapes:
             x = shape["x"] * self.cell_size
             y = shape["y"] * self.cell_size
             if shape["type"] == "square":
-                ET.SubElement(svg, 'rect', x=str(x), y=str(y),
-                              width=str(self.cell_size), height=str(self.cell_size),
-                              fill="black")
+                painter.drawRect(x, y, self.cell_size, self.cell_size)
+            else:
+                points = [
+                    QPointF(x + self.cell_size / 2, y),
+                    QPointF(x + self.cell_size, y + self.cell_size),
+                    QPointF(x, y + self.cell_size),
+                ]
+                painter.drawPolygon(QPolygonF(points))
+
+        pen = QPen(QColor("red"))
+        pen.setWidth(2)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawRect(
+            self.cursor_x * self.cell_size,
+            self.cursor_y * self.cell_size,
+            self.cell_size,
+            self.cell_size,
+        )
+
+    def keyPressEvent(self, event):
+        key = event.key()
+        if key == Qt.Key.Key_Left and self.cursor_x > 0:
+            self.cursor_x -= 1
+        elif key == Qt.Key.Key_Right and self.cursor_x < self.cols - 1:
+            self.cursor_x += 1
+        elif key == Qt.Key.Key_Up and self.cursor_y > 0:
+            self.cursor_y -= 1
+        elif key == Qt.Key.Key_Down and self.cursor_y < self.rows - 1:
+            self.cursor_y += 1
+        elif key == Qt.Key.Key_S:
+            self.place_square()
+        elif key == Qt.Key.Key_T:
+            self.place_triangle()
+        self.update()
+
+    def place_square(self):
+        self.shapes.append({"type": "square", "x": self.cursor_x, "y": self.cursor_y})
+
+    def place_triangle(self):
+        self.shapes.append({"type": "triangle", "x": self.cursor_x, "y": self.cursor_y})
+
+    def save_svg(self):
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Save as SVG", "", "SVG files (*.svg)"
+        )
+        if not filename:
+            return
+        svg = ET.Element(
+            "svg",
+            width=str(self.width),
+            height=str(self.height),
+            xmlns="http://www.w3.org/2000/svg",
+            version="1.1",
+        )
+        for i in range(self.cols + 1):
+            x = i * self.cell_size
+            ET.SubElement(
+                svg,
+                "line",
+                x1=str(x),
+                y1="0",
+                x2=str(x),
+                y2=str(self.height),
+                stroke="lightgray",
+                **{"stroke-width": "1"}
+            )
+        for j in range(self.rows + 1):
+            y = j * self.cell_size
+            ET.SubElement(
+                svg,
+                "line",
+                x1="0",
+                y1=str(y),
+                x2=str(self.width),
+                y2=str(y),
+                stroke="lightgray",
+                **{"stroke-width": "1"}
+            )
+        for shape in self.shapes:
+            x = shape["x"] * self.cell_size
+            y = shape["y"] * self.cell_size
+            if shape["type"] == "square":
+                ET.SubElement(
+                    svg,
+                    "rect",
+                    x=str(x),
+                    y=str(y),
+                    width=str(self.cell_size),
+                    height=str(self.cell_size),
+                    fill="black",
+                )
             else:
                 points = [
                     f"{x + self.cell_size / 2},{y}",
                     f"{x + self.cell_size},{y + self.cell_size}",
-                    f"{x},{y + self.cell_size}"
+                    f"{x},{y + self.cell_size}",
                 ]
-                ET.SubElement(svg, 'polygon', points=" ".join(points), fill="black")
+                ET.SubElement(
+                    svg, "polygon", points=" ".join(points), fill="black"
+                )
         dom = minidom.parseString(ET.tostring(svg))
-        with open(filename, 'w', encoding='utf-8') as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(dom.toprettyxml())
 
     def save_pdf(self):
-        filename = filedialog.asksaveasfilename(defaultextension=".pdf",
-                                                filetypes=[("PDF files", "*.pdf")])
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Save as PDF", "", "PDF files (*.pdf)"
+        )
         if not filename:
             return
         if pdfcanvas is None:
             raise RuntimeError("reportlab is required for PDF export")
         c = pdfcanvas.Canvas(filename, pagesize=(self.width, self.height))
-        # Convert from Tkinter's top-left origin to ReportLab's bottom-left origin
         for i in range(self.cols + 1):
             x = i * self.cell_size
             c.line(x, 0, x, self.height)
@@ -160,11 +186,26 @@ class GridEditor:
         c.save()
 
 
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Grid Editor")
+        self.grid = GridWidget()
+        self.setCentralWidget(self.grid)
+        file_menu = self.menuBar().addMenu("File")
+        svg_action = QAction("Save as SVG", self)
+        svg_action.triggered.connect(self.grid.save_svg)
+        file_menu.addAction(svg_action)
+        pdf_action = QAction("Save as PDF", self)
+        pdf_action.triggered.connect(self.grid.save_pdf)
+        file_menu.addAction(pdf_action)
+
+
 def main():
-    root = tk.Tk()
-    root.title("Grid Editor")
-    GridEditor(root)
-    root.mainloop()
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.exec()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace Tkinter UI with a PyQt6-based grid editor supporting keyboard movement and shape placement.
- Preserve SVG and PDF export features from the original application.
- Update documentation to reflect PyQt6 usage and dependencies.

## Testing
- `python -m py_compile app.py`
- `pip install PyQt6` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c43f73d374832cb45284a299d9448d